### PR TITLE
Mark C extension methods as `Ractor`-safe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ extattr はファイルシステムの拡張属性を操作するライブラリ
 
   - package name: [extattr](https://rubygems.org/gems/extattr)
   - Author: dearblue
-  - Version: 0.3
+  - Version: 0.4
   - Product quality: technical preview
   - License: [2-clause BSD License](LICENSE.md)
   - Project page: <https://github.com/dearblue/ruby-extattr>

--- a/ext/extattr.c
+++ b/ext/extattr.c
@@ -476,6 +476,9 @@ ext_s_delete_link(VALUE mod, VALUE path, VALUE namespace, VALUE name)
 void
 Init_extattr(void)
 {
+#if HAVE_RB_EXT_RACTOR_SAFE
+    rb_ext_ractor_safe(true);
+#endif
     id_downcase = rb_intern("downcase");
     id_to_path = rb_intern("to_path");
 

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -2,6 +2,8 @@
 
 require "mkmf"
 
+have_func("rb_ext_ractor_safe", "ruby.h")
+
 case
 when have_header("sys/extattr.h")
 


### PR DESCRIPTION
`ExtAttr`ありがとう！

I want to use `ExtAttr` inside a `Ractor`, but it has to be enabled first: https://docs.ruby-lang.org/en/master/doc/extension_rdoc.html#label-Appendix+F.+Ractor+support

"By default, all C extensions are recognized as `Ractor`-unsafe. If C extension becomes `Ractor`-safe, the extension should call `rb_ext_ractor_safe(true)` at the `Init_` function and all defined method marked as `Ractor`-safe. `Ractor`-unsafe C-methods only been called from main-ractor. If non-main ractor calls it, then `Ractor::UnsafeError` is raised."

I did that, added a new unit test, and bumped `ExtAttr`'s version to 0.4 so you can go back to 0.3 if this causes problems.


Before, ver 0.3:
```
[okeeblow@emi#CHECKING-YOU-OUT] setfattr -n user.mime-type -v "image/jpeg" ~/xattr-224031-jpeg

[okeeblow@emi#CHECKING-YOU-OUT] gem install ../../ruby-extattr/extattr-0.3.TRYOUT.20210910.191933.gem
Building native extensions. This could take a while...
Successfully installed extattr-0.3.TRYOUT.20210910.191933
Parsing documentation for extattr-0.3.TRYOUT.20210910.191933
Installing ri documentation for extattr-0.3.TRYOUT.20210910.191933
Done installing documentation for extattr after 0 seconds
1 gem installed

[okeeblow@emi#CHECKING-YOU-OUT] ruby -r 'extattr' -e 'p ExtAttr.list("/home/okeeblow/xattr-224031-jpeg", ExtAttr::USER)'                
["mime_type"]

[okeeblow@emi#CHECKING-YOU-OUT] ruby -r 'extattr' -e 'p Ractor.new { ExtAttr.list("/home/okeeblow/xattr-224031-jpeg", ExtAttr::USER) }.take'
#<Thread:0x0000562476176128 run> terminated with exception (report_on_exception is true):
-e:1:in `list': ractor unsafe method called from not main ractor (Ractor::UnsafeError)
        from -e:1:in `block in <main>'
<internal:ractor>:694:in `take': thrown by remote Ractor. (Ractor::RemoteError)
        from -e:1:in `<main>'
-e:1:in `list': ractor unsafe method called from not main ractor (Ractor::UnsafeError)
        from -e:1:in `block in <main>'
```


After, ver 0.4:
```
[okeeblow@emi#CHECKING-YOU-OUT] gem uninstall -x extattr
Removing extattr
Successfully uninstalled extattr-0.3.TRYOUT.20210910.191933

[okeeblow@emi#CHECKING-YOU-OUT] gem install ../../ruby-extattr/extattr-0.4.TRYOUT.20210910.192055.gem                                       
Building native extensions. This could take a while...
Successfully installed extattr-0.4.TRYOUT.20210910.192055
Parsing documentation for extattr-0.4.TRYOUT.20210910.192055
Installing ri documentation for extattr-0.4.TRYOUT.20210910.192055
Done installing documentation for extattr after 0 seconds
1 gem installed

[okeeblow@emi#CHECKING-YOU-OUT] ruby -r 'extattr' -e 'p ExtAttr.list("/home/okeeblow/xattr-224031-jpeg", ExtAttr::USER)'                    
["mime_type"]

[okeeblow@emi#CHECKING-YOU-OUT] ruby -r 'extattr' -e 'p Ractor.new { ExtAttr.list("/home/okeeblow/xattr-224031-jpeg", ExtAttr::USER) }.take'
["mime_type"]
```


Tests pass on Ruby 3.0:
```
[okeeblow@emi#ruby-extattr] ruby -v
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-linux]

[okeeblow@emi#ruby-extattr] ruby test/test_extattr.rb
Loaded suite test/test_extattr
Started
...rm -rf /tmp/20210910-25338-wt4t2i.ruby-extattr.test-work

Finished in 0.00667254 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------
3 tests, 18 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------
449.60 tests/s, 2697.62 assertions/s
```


Tests pass on Ruby 2.7:
```
[okeeblow@emi#okeeblow] ruby -v
ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-linux-gnu]

[okeeblow@emi#okeeblow] gem install ~/Works/ruby-extattr/extattr-0.4.TRYOUT.20210910.192055.gem    
Building native extensions. This could take a while...
Successfully installed extattr-0.4.TRYOUT.20210910.192055
Parsing documentation for extattr-0.4.TRYOUT.20210910.192055
Installing ri documentation for extattr-0.4.TRYOUT.20210910.192055
Done installing documentation for extattr after 0 seconds
1 gem installed

[okeeblow@emi#okeeblow] ruby2.7 ~/Works/ruby-extattr/test/test_extattr.rb 
Loaded suite /home/okeeblow/Works/ruby-extattr/test/test_extattr
Started
...rm -rf /tmp/20210910-25700-1csymsz.ruby-extattr.test-work


Finished in 0.001878633 seconds.
--------------------------------------------------------------------------------
3 tests, 12 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------
1596.91 tests/s, 6387.62 assertions/s
```